### PR TITLE
Use aria-label attribute for better reliability

### DIFF
--- a/admute.js
+++ b/admute.js
@@ -11,7 +11,7 @@ let forwardBtn;
 
 function getMuteBtn() {
     return new Promise(async (resolve) => {
-        muteBtn = document.querySelector('.spoticon-volume-16.control-button.volume-bar__icon');
+        muteBtn = document.querySelector('[aria-label="Mute"]');
         if(muteBtn) {
             resolve();
         } else {
@@ -23,7 +23,7 @@ function getMuteBtn() {
 
 function getForwardBtn() {
     return new Promise(async(resolve) => {
-        forwardBtn = document.querySelector('.control-button.spoticon-skip-forward-16');
+        forwardBtn = document.querySelector('[aria-label="Next"]');
         if(forwardBtn) {
             resolve();
         } else {


### PR DESCRIPTION
The forward button didn't have the class as specified in the code (might've changed since the code was written)
aria-label is better in my opinion since it's used by screen readers and stuff, so its less likely to change